### PR TITLE
Adds Django 4 compatbility for this library

### DIFF
--- a/maintenancemode/__init__.py
+++ b/maintenancemode/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 3, 1)  # following PEP 386
+VERSION = (1, 3, 2)  # following PEP 386
 DEV_N = None
 
 

--- a/maintenancemode/models.py
+++ b/maintenancemode/models.py
@@ -1,7 +1,10 @@
 from __future__ import unicode_literals
 
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import ugettext_lazy as _
+except ImportError:
+    from django.utils.translation import gettext_lazy as _
 from django.db import IntegrityError
 from django.contrib.sites.models import Site
 

--- a/maintenancemode/models.py
+++ b/maintenancemode/models.py
@@ -4,6 +4,7 @@ from django.db import models
 try:
     from django.utils.translation import ugettext_lazy as _
 except ImportError:
+    # Needed for django 4 which renames ugettext_lazy
     from django.utils.translation import gettext_lazy as _
 from django.db import IntegrityError
 from django.contrib.sites.models import Site


### PR DESCRIPTION
Django 4 has renamed ugettext. Needs the following:

try:
    from django.utils.translation import ugettext_lazy as _
except ImportError:
    # Needed for django 4 which renames ugettext_lazy
    from django.utils.translation import gettext_lazy as _